### PR TITLE
Fix how GNU ELPA Mirror uses --mirror

### DIFF
--- a/gnu_elpa_mirror.py
+++ b/gnu_elpa_mirror.py
@@ -51,6 +51,7 @@ def clone_git_repo(
     bare=False,
     exclude_patterns=[],
     additional_refspecs=[],
+    recursive=False,
 ):
     # Basically reimplement --mirror ourselves because it is the most
     # elegant way to solve https://stackoverflow.com/a/54413257/3538165.
@@ -120,19 +121,20 @@ def clone_git_repo(
             cwd=repo_dir,
             check=True,
         )
-        subprocess.run(
-            [
-                "git",
-                "submodule",
-                "update",
-                "--init",
-                "--recursive",
-                "--checkout",
-                "--force",
-            ],
-            cwd=repo_dir,
-            check=True,
-        )
+        if recursive:
+            subprocess.run(
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                    "--checkout",
+                    "--force",
+                ],
+                cwd=repo_dir,
+                check=True,
+            )
 
 
 def push_git_repo(git_url, repo_dir, repo_obj):
@@ -240,8 +242,11 @@ def mirror_gnu_elpa(args, api, existing_repos):
         exclude_patterns=["/emacs"],
     )
     subprocess.run(
-        ["git", "remote", "remove", "origin"], cwd=GNU_ELPA_SUBDIR, check=True
+        ["git", "remote", "remove", "origin"],
+        cwd=GNU_ELPA_SUBDIR,
+        check=False,
     )
+    shutil.rmtree(GNU_ELPA_SUBDIR / ".git" / "worktrees")
     subprocess.run(
         ["git", "remote", "add", "origin", GNU_ELPA_GIT_URL],
         cwd=GNU_ELPA_SUBDIR,

--- a/gnu_elpa_mirror.py
+++ b/gnu_elpa_mirror.py
@@ -93,6 +93,9 @@ def clone_git_repo(
             check=True,
         )
         output = result.stdout.decode().splitlines()
+        if not output:
+            # Probably a new/empty repository
+            return
         match = re.fullmatch(
             r"ref: (refs/heads/.+?)\s+HEAD",
             output[0],


### PR DESCRIPTION
Using `--bare` instead of `--mirror` in the old code was clearly wrong since it simply does not do mirroring. To work around the reason that flag was used in the first place (see comments in original code), we need to re-write the Git interop code to use lower-level commands, which is not hard, just requires a little understanding of refspec internals.

This should prevent issues like https://github.com/radian-software/gnu-elpa-mirror/issues/12 from occurring in future.

Fixes #12 
Fixes #14 